### PR TITLE
Make image hotspot more accessible

### DIFF
--- a/scripts/hotspot.js
+++ b/scripts/hotspot.js
@@ -14,19 +14,23 @@
    * @param  {boolean} isSmallDeviceCB
    * @param  {H5P.ImageHotspots} parent
    */
-  ImageHotspots.Hotspot = function (config, color, id, isSmallDeviceCB, parent) {
+  ImageHotspots.Hotspot = function (config, color, id, isSmallDeviceCB, parent, index) {
     var self = this;
     this.config = config;
     this.visible = false;
     this.id = id;
     this.isSmallDeviceCB = isSmallDeviceCB;
+    this.tabIndex = index;
 
     if (!this.config.content.length) {
       throw new Error('Missing mandatory library for hotspot');
     }
 
     this.$element = $('<div/>', {
+      'id': 'hotspot-' + this.tabIndex,
       'class': 'h5p-image-hotspot',
+      'title': 'Clickable hotspot number: '+ this.tabIndex,
+      'tabindex': this.tabIndex,
       click: function(){
         if(self.visible) {
           self.hidePopup();
@@ -76,7 +80,10 @@
     var self = this;
 
     // Create popup content:
-    var $popupBody = $('<div/>', {'class': 'h5p-image-hotspot-popup-body'});
+    var $popupBody = $('<div/>', {
+      'class': 'h5p-image-hotspot-popup-body',
+      'title': 'The hotspot name is: ' + self.config.header
+    });
 
     this.actionInstances = [];
     var waitForLoaded = [];

--- a/scripts/image-hotspots.js
+++ b/scripts/image-hotspots.js
@@ -67,6 +67,7 @@ H5P.ImageHotspots = (function ($, EventDispatcher) {
     if (this.options.image && this.options.image.path) {
       this.$image = $('<img/>', {
         'class': 'h5p-image-hotspots-background',
+        'alt': this.options.alt,
         src: H5P.getPath(this.options.image.path, this.id)
       }).appendTo(this.$hotspotContainer);
     }
@@ -79,7 +80,7 @@ H5P.ImageHotspots = (function ($, EventDispatcher) {
     var numHotspots = this.options.hotspots.length;
     for(var i=0; i<numHotspots; i++) {
       try {
-        new ImageHotspots.Hotspot(this.options.hotspots[i], this.options.color, this.id, isSmallDevice, self).appendTo(this.$hotspotContainer);
+        new ImageHotspots.Hotspot(this.options.hotspots[i], this.options.color, this.id, isSmallDevice, self, i + 1).appendTo(this.$hotspotContainer);
       }
       catch (e) {
         H5P.error(e);

--- a/semantics.json
+++ b/semantics.json
@@ -18,6 +18,12 @@
     }
   },
   {
+    "label": "Alternate text for the image",
+    "name": "alt",
+    "type": "text",
+    "description": "Put the alternate text here to make the image accessible!"
+  },
+  {
     "name": "hotspots",
     "type": "list",
     "entity": "hotspot",


### PR DESCRIPTION
Create an "alt" text field for the main image, and makes the hotspots more convenient to navigate using tab and shift+tab keys. 
And also make it readable by ChromeVox or other screen readers. 