### PR TITLE
customize appearance of hotspot icon. Select icon or use your own.

### DIFF
--- a/library.json
+++ b/library.json
@@ -50,6 +50,11 @@
       "machineName": "H5PEditor.ColorSelector",
       "majorVersion": 1,
       "minorVersion": 2
+    },
+    {
+      "machineName": "H5PEditor.ShowWhen",
+      "majorVersion": 1,
+      "minorVersion": 0
     }
   ]
 }

--- a/scripts/hotspot.js
+++ b/scripts/hotspot.js
@@ -16,14 +16,20 @@
    * @param  {string} icon
    * @param  {image} iconImage
    */
-  ImageHotspots.Hotspot = function (config, color, id, isSmallDeviceCB, parent, icon, iconImage) {
+  ImageHotspots.Hotspot = function (config, color, id, isSmallDeviceCB, parent, icon, iconImage, iconType) {
     var self = this;
     this.config = config;
     this.visible = false;
     this.id = id;
     this.isSmallDeviceCB = isSmallDeviceCB;
-    // A utility variable so you don't have to always check if there is an iconImage.
-    var iconImageExists = (iconImage == null ? false : true); 
+    // A utility variable to check if a Predefined icon or an uploaded image should be used.
+    var iconImageExists;
+    // If there is an image loaded & the iconType is image.
+    if (iconImage !== undefined && iconType === 'image') {
+      iconImageExists = true;
+    } else {
+      iconImageExists = false;
+    }
 
     if (this.config.content === undefined  || this.config.content.length === 0) {
       throw new Error('Missing content configuration for hotspot. Please fix in editor.');

--- a/scripts/hotspot.js
+++ b/scripts/hotspot.js
@@ -37,7 +37,7 @@
     
     // Check if there is an iconImage that should be used instead of fontawesome icons to determine the html element.
     this.$element = $((iconImageExists ? '<img/>' : '<div/>'), {
-      'class': 'h5p-image-hotspot ' + 'h5p-image-hotspot-' + icon,
+      'class': 'h5p-image-hotspot ' + (!iconImageExists ? 'h5p-image-hotspot-' + icon : ''),
       click: function(){
         if(self.visible) {
           self.hidePopup();
@@ -46,16 +46,14 @@
           self.showPopup();
         }
         return false;
-      }
+      },
+      // If there is the iconImage, then add the src to the icon.
+      src: iconImageExists ? H5P.getPath(iconImage.path, this.id) : undefined
     }).css({
       top: this.config.position.y + '%',
       left: this.config.position.x + '%',
       color: color
     });
-    // If there is the iconImage, then add the src to the icon.
-    if (iconImageExists) {
-      this.$element.attr("src", H5P.getPath(iconImage.path, this.id));
-    }
     
     parent.on('resize', function () {
       if (self.popup) {

--- a/scripts/hotspot.js
+++ b/scripts/hotspot.js
@@ -13,20 +13,25 @@
    * @param  {number} id
    * @param  {boolean} isSmallDeviceCB
    * @param  {H5P.ImageHotspots} parent
+   * @param  {string} icon
+   * @param  {image} iconImage
    */
-  ImageHotspots.Hotspot = function (config, color, id, isSmallDeviceCB, parent) {
+  ImageHotspots.Hotspot = function (config, color, id, isSmallDeviceCB, parent, icon, iconImage) {
     var self = this;
     this.config = config;
     this.visible = false;
     this.id = id;
     this.isSmallDeviceCB = isSmallDeviceCB;
+    // A utility variable so you don't have to always check if there is an iconImage.
+    var iconImageExists = (iconImage == null ? false : true); 
 
     if (this.config.content === undefined  || this.config.content.length === 0) {
       throw new Error('Missing content configuration for hotspot. Please fix in editor.');
     }
-
-    this.$element = $('<div/>', {
-      'class': 'h5p-image-hotspot',
+    
+    // Check if there is an iconImage that should be used instead of fontawesome icons to determine the html element.
+    this.$element = $((iconImageExists ? '<img/>' : '<div/>'), {
+      'class': 'h5p-image-hotspot ' + 'h5p-image-hotspot-' + icon,
       click: function(){
         if(self.visible) {
           self.hidePopup();
@@ -41,7 +46,11 @@
       left: this.config.position.x + '%',
       color: color
     });
-
+    // If there is the iconImage, then add the src to the icon.
+    if (iconImageExists) {
+      this.$element.attr("src", H5P.getPath(iconImage.path, this.id));
+    }
+    
     parent.on('resize', function () {
       if (self.popup) {
 

--- a/scripts/image-hotspots.js
+++ b/scripts/image-hotspots.js
@@ -79,7 +79,7 @@ H5P.ImageHotspots = (function ($, EventDispatcher) {
     var numHotspots = this.options.hotspots.length;
     for(var i=0; i<numHotspots; i++) {
       try {
-        new ImageHotspots.Hotspot(this.options.hotspots[i], this.options.color, this.id, isSmallDevice, self, this.options.icon, this.options.iconImage).appendTo(this.$hotspotContainer);
+        new ImageHotspots.Hotspot(this.options.hotspots[i], this.options.color, this.id, isSmallDevice, self, this.options.icon, this.options.iconImage, this.options.iconType).appendTo(this.$hotspotContainer);
       }
       catch (e) {
         H5P.error(e);

--- a/scripts/image-hotspots.js
+++ b/scripts/image-hotspots.js
@@ -79,7 +79,7 @@ H5P.ImageHotspots = (function ($, EventDispatcher) {
     var numHotspots = this.options.hotspots.length;
     for(var i=0; i<numHotspots; i++) {
       try {
-        new ImageHotspots.Hotspot(this.options.hotspots[i], this.options.color, this.id, isSmallDevice, self).appendTo(this.$hotspotContainer);
+        new ImageHotspots.Hotspot(this.options.hotspots[i], this.options.color, this.id, isSmallDevice, self, this.options.icon, this.options.iconImage).appendTo(this.$hotspotContainer);
       }
       catch (e) {
         H5P.error(e);

--- a/semantics.json
+++ b/semantics.json
@@ -20,11 +20,38 @@
     }
   },
   {
-    "name": "icon",
+    "name": "iconType",
     "type": "select",
     "label": "Hotspot Icon",
+    "options": [
+      {
+        "value": "icon",
+        "label": "Predefined icon"
+      },
+      {
+        "value": "image",
+        "label": "Uploaded image"
+      }
+    ],
+    "default": "icon"
+  },
+  {
+    "name": "icon",
+    "type": "select",
+    "label": "Predefined icon",
     "importance": "medium",
-    "description": "The icon of the hotspots",
+    "description": "Using a predefined icon for the hotspot.",
+    "widget": "showWhen",
+    "showWhen": {
+      "rules": [
+        {
+          "field": "iconType",
+          "equals": [
+            "icon"
+          ]
+        }
+      ]
+    },
     "options": [
       {
         "value": "plus",
@@ -32,7 +59,7 @@
       },
       {
         "value": "minus",
-        "label": "minus"
+        "label": "Minus"
       },
       {
         "value": "times",
@@ -60,9 +87,20 @@
   {
     "name": "iconImage",
     "type": "image",
-    "label": "Icon image override",
-    "optional": true,
-    "description": "Override the existing icon for hotspot and use your own. This overrides the Hotspot Color & Hotspot Icon settings.<br>75px by 75px is recommended for your image."
+    "label": "Uploaded image",
+    "optional": false,
+    "description": "Use your own image for the hotspot icon.<br>75px by 75px is recommended for your image.",
+    "widget": "showWhen",
+    "showWhen": {
+      "rules": [
+        {
+          "field": "iconType",
+          "equals": [
+            "image"
+          ]
+        }
+      ]
+    }
   },
   {
     "name": "hotspots",

--- a/semantics.json
+++ b/semantics.json
@@ -20,6 +20,51 @@
     }
   },
   {
+    "name": "icon",
+    "type": "select",
+    "label": "Hotspot Icon",
+    "importance": "medium",
+    "description": "The icon of the hotspots",
+    "options": [
+      {
+        "value": "plus",
+        "label": "Plus"
+      },
+      {
+        "value": "minus",
+        "label": "minus"
+      },
+      {
+        "value": "times",
+        "label": "Times"
+      },
+      {
+        "value": "check",
+        "label": "Check"
+      },
+      {
+        "value": "question",
+        "label": "Question"
+      },
+      {
+        "value": "info",
+        "label": "Info"
+      },
+      {
+        "value": "exclamation",
+        "label": "Exclamation"
+      }
+    ],
+    "default": "plus"
+  },
+  {
+    "name": "iconImage",
+    "type": "image",
+    "label": "Icon image override",
+    "optional": true,
+    "description": "Override the existing icon for hotspot and use your own. This overrides the Hotspot Color & Hotspot Icon settings.<br>75px by 75px is recommended for your image."
+  },
+  {
     "name": "hotspots",
     "type": "list",
     "entity": "hotspot",

--- a/styles/image-hotspots.css
+++ b/styles/image-hotspots.css
@@ -43,12 +43,32 @@
 }
 .h5p-image-hotspot:before {
   font-family: H5PFontAwesome4;
-  content: '\f055';
   width: 1.2em;
   height: 1.2em;
   font-size: 1.2em;
   line-height: 1.2em;
   margin: 0 0.1em;
+}
+.h5p-image-hotspot-plus:before {
+  content: '\f055';
+}
+.h5p-image-hotspot-minus:before {
+  content: '\f056';
+}
+.h5p-image-hotspot-times:before {
+  content: '\f057';
+}
+.h5p-image-hotspot-check:before {
+  content: '\f058';
+}
+.h5p-image-hotspot-question:before {
+  content: '\f059';
+}
+.h5p-image-hotspot-info:before {
+  content: '\f05a';
+}
+.h5p-image-hotspot-exclamation:before {
+  content: '\f06a';
 }
 .h5p-image-hotspot-popup {
   position: absolute;


### PR DESCRIPTION
Based on https://h5p.org/node/40274 & https://h5p.org/node/38454.

I selected icons from http://fontawesome.bootstrapcheatsheets.com/ (the website lists font awesome icons v.4.5.0) that were similar to .fa-plus-circle so people have a couple of options of the icon. I also added the ability for content authors to upload their own image to be used instead of the icons. This overrides the hotspot color & hotspot icon.

This pull request doesn't include part of https://h5p.org/node/38454 which requests the ability for people to mouseover instead of click/touch. 

Please let me know what you think of the pull request or if I can contribute to H5P differently. Thanks.

-Nate