### PR TITLE
Add customizing options for popups

### DIFF
--- a/language/.en.json
+++ b/language/.en.json
@@ -23,10 +23,6 @@
             "description": "Click on the thumbnail image to place the hotspot"
           },
           {
-            "label": "Cover entire background image",
-            "description": "When the user clicks the hotspot the popup will cover the entire background image"
-          },
-          {
             "label": "Header",
             "description": "Optional header for the popup"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Content Item"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Cover entire background image"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/af.json
+++ b/language/af.json
@@ -23,10 +23,6 @@
             "description": "Click on the thumbnail image to place the hotspot"
           },
           {
-            "label": "Cover entire background image",
-            "description": "When the user clicks the hotspot the popup will cover the entire background image"
-          },
-          {
             "label": "Header",
             "description": "Optional header for the popup"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Content Item"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Cover entire background image"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/ar.json
+++ b/language/ar.json
@@ -23,10 +23,6 @@
             "description": "انقر على الصورة المصغرة لمكان نقطة الاتصال"
           },
           {
-            "label": "تغطية صورة الخلفية بأكملها",
-            "description": "عندما ينقر المستخدم على نقطة الاتصال ، ستغطي النافذة المنبثقة صورة الخلفية بأكملها"
-          },
-          {
             "label": "الترويسة",
             "description": "ترويسة اختيارية للنوافذ المنبثقة"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "عنصر المحتوى"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "تغطية صورة الخلفية بأكملها"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/bs.json
+++ b/language/bs.json
@@ -23,10 +23,6 @@
             "description": "Click on the thumbnail image to place the hotspot"
           },
           {
-            "label": "Cover entire background image",
-            "description": "When the user clicks the hotspot the popup will cover the entire background image"
-          },
-          {
             "label": "Header",
             "description": "Optional header for the popup"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Content Item"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Cover entire background image"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/ca.json
+++ b/language/ca.json
@@ -23,10 +23,6 @@
             "description": "Click on the thumbnail image to place the hotspot"
           },
           {
-            "label": "Cover entire background image",
-            "description": "When the user clicks the hotspot the popup will cover the entire background image"
-          },
-          {
             "label": "Header",
             "description": "Optional header for the popup"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Content Item"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Cover entire background image"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/cs.json
+++ b/language/cs.json
@@ -23,10 +23,6 @@
             "description": "Click on the thumbnail image to place the hotspot"
           },
           {
-            "label": "Cover entire background image",
-            "description": "When the user clicks the hotspot the popup will cover the entire background image"
-          },
-          {
             "label": "Header",
             "description": "Optional header for the popup"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Content Item"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Cover entire background image"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/da.json
+++ b/language/da.json
@@ -23,10 +23,6 @@
             "description": "Click on the thumbnail image to place the hotspot"
           },
           {
-            "label": "Cover entire background image",
-            "description": "When the user clicks the hotspot the popup will cover the entire background image"
-          },
-          {
             "label": "Header",
             "description": "Optional header for the popup"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Content Item"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Cover entire background image"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/de.json
+++ b/language/de.json
@@ -23,10 +23,6 @@
             "description": "Klicke das Vorschaubild an, um den Hotspot zu platzieren"
           },
           {
-            "label": "Überdecke das gesamte Hintergrundbild",
-            "description": "Sobald der Lernende auf den Hotspot klickt, wird das erscheinende Fenster den gesamten Hintergrund überdecken"
-          },
-          {
             "label": "Kopfzeile",
             "description": "Optionale Kopfzeile für das Fenster"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Inhaltsobjekt"
             }
+          },
+          {
+            "label": "Popup-Einstellungen",
+            "fields": [
+              {
+                "label": "Größe und Position",
+                "description": "Lege fest, wie viel Platz das Popup einnimmt, wenn auf den Hotspot geklickt wird",
+                "options": [
+                  {
+                    "label": "Überdecke den freien Platz neben dem Hotspot"
+                  },
+                  {
+                    "label": "Überdecke das gesamte Hintergrundbild"
+                  },
+                  {
+                    "label": "Individuell"
+                  }
+                ]
+              },
+              {
+                "label": "Maximale Breite (in Prozent)",
+                "description": "Die Breite des Popups wird auf den angegebenen Prozentsatz relativ zur Breite des Hintergrundbildes begrenzt"
+              },
+              {
+                "label": "Position",
+                "description": "Standardmäßig wird das Popup links oder rechts neben dem zugehörigen Hotspot angezeigt, je nachdem, auf welcher Seite mehr Platz besteht",
+                "options": [
+                  {
+                    "label": "Automatisch"
+                  },
+                  {
+                    "label": "Links vom Hotspot"
+                  },
+                  {
+                    "label": "Rechts vom Hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/el.json
+++ b/language/el.json
@@ -23,10 +23,6 @@
             "description": "Click on the thumbnail image to place the hotspot"
           },
           {
-            "label": "Cover entire background image",
-            "description": "When the user clicks the hotspot the popup will cover the entire background image"
-          },
-          {
             "label": "Header",
             "description": "Optional header for the popup"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Content Item"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Cover entire background image"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/es.json
+++ b/language/es.json
@@ -23,10 +23,6 @@
             "description": "Haga clic en la imagen en miniatura para colocar el punto de acceso hotspot"
           },
           {
-            "label": "Cubrir toda la imagen de fondo",
-            "description": "Cuando el usuario hace clic en el hotspot, la ventana emergente cubrirá toda la imagen de fondo"
-          },
-          {
             "label": "Encabezado",
             "description": "Encabezado opcional para la ventana emergente"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Item del contenido"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Cubrir toda la imagen de fondo"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/et.json
+++ b/language/et.json
@@ -23,10 +23,6 @@
             "description": "Tulipunkti asetamiseks kliki pisipildil"
           },
           {
-            "label": "Kata kogu taustapilt",
-            "description": "Kui kasutaja klikib tulipunktil, siis katab hüpikaken kogu taustapildi"
-          },
-          {
             "label": "Päis",
             "description": "Valikuline hüpikakna pealkiri"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Sisuelement"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Kata kogu taustapilt"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/eu.json
+++ b/language/eu.json
@@ -23,10 +23,6 @@
             "description": "Egin klik miniaturan leku beroa kokatzeko"
           },
           {
-            "label": "Atzeko planoko irudi osoa estaltzen du",
-            "description": "Erabiltzaileak leku beroan klik egiten duenean popupak atzeko planoko irudi guztia estaliko du"
-          },
-          {
             "label": "Goiburua",
             "description": "Popuparen aukerako goiburua"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Eduki-elementua"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Atzeko planoko irudi osoa estaltzen du"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/fi.json
+++ b/language/fi.json
@@ -23,10 +23,6 @@
             "description": "Click on the thumbnail image to place the hotspot"
           },
           {
-            "label": "Cover entire background image",
-            "description": "When the user clicks the hotspot the popup will cover the entire background image"
-          },
-          {
             "label": "Header",
             "description": "Optional header for the popup"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Content Item"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Cover entire background image"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/fr.json
+++ b/language/fr.json
@@ -23,10 +23,6 @@
             "description": "Cliquez sur la miniature pour positionner la puce cliquable."
           },
           {
-            "label": "Recouvrir toute l'image d'arrière-plan",
-            "description": "Quand l'utilisateur cliquera sur la puce cliquable, le popup recouvrira toute l'image d'arrière-plan."
-          },
-          {
             "label": "Titre",
             "description": "Titre facultatif du popup."
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Type de contenu"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Recouvrir toute l'image d'arrière-plan"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/he.json
+++ b/language/he.json
@@ -23,10 +23,6 @@
             "description": "Click on the thumbnail image to place the hotspot"
           },
           {
-            "label": "Cover entire background image",
-            "description": "When the user clicks the hotspot the popup will cover the entire background image"
-          },
-          {
             "label": "Header",
             "description": "Optional header for the popup"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Content Item"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Cover entire background image"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/hu.json
+++ b/language/hu.json
@@ -23,10 +23,6 @@
             "description": "Click on the thumbnail image to place the hotspot"
           },
           {
-            "label": "Cover entire background image",
-            "description": "When the user clicks the hotspot the popup will cover the entire background image"
-          },
-          {
             "label": "Header",
             "description": "Optional header for the popup"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Content Item"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Cover entire background image"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/it.json
+++ b/language/it.json
@@ -23,10 +23,6 @@
             "description": "Click on the thumbnail image to place the hotspot"
           },
           {
-            "label": "Cover entire background image",
-            "description": "When the user clicks the hotspot the popup will cover the entire background image"
-          },
-          {
             "label": "Header",
             "description": "Optional header for the popup"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Content Item"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Cover entire background image"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/ja.json
+++ b/language/ja.json
@@ -23,10 +23,6 @@
             "description": "Click on the thumbnail image to place the hotspot"
           },
           {
-            "label": "Cover entire background image",
-            "description": "When the user clicks the hotspot the popup will cover the entire background image"
-          },
-          {
             "label": "Header",
             "description": "Optional header for the popup"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Content Item"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Cover entire background image"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/ko.json
+++ b/language/ko.json
@@ -23,10 +23,6 @@
             "description": "Click on the thumbnail image to place the hotspot"
           },
           {
-            "label": "Cover entire background image",
-            "description": "When the user clicks the hotspot the popup will cover the entire background image"
-          },
-          {
             "label": "Header",
             "description": "Optional header for the popup"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Content Item"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Cover entire background image"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/nb.json
+++ b/language/nb.json
@@ -23,10 +23,6 @@
             "description": "Click on the thumbnail image to place the hotspot"
           },
           {
-            "label": "Cover entire background image",
-            "description": "When the user clicks the hotspot the popup will cover the entire background image"
-          },
-          {
             "label": "Header",
             "description": "Optional header for the popup"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Content Item"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Cover entire background image"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/nl.json
+++ b/language/nl.json
@@ -23,10 +23,6 @@
             "description": "Click on the thumbnail image to place the hotspot"
           },
           {
-            "label": "Cover entire background image",
-            "description": "When the user clicks the hotspot the popup will cover the entire background image"
-          },
-          {
             "label": "Header",
             "description": "Optional header for the popup"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Content Item"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Cover entire background image"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/nn.json
+++ b/language/nn.json
@@ -23,10 +23,6 @@
             "description": "Click on the thumbnail image to place the hotspot"
           },
           {
-            "label": "Cover entire background image",
-            "description": "When the user clicks the hotspot the popup will cover the entire background image"
-          },
-          {
             "label": "Header",
             "description": "Optional header for the popup"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Content Item"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Cover entire background image"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/pl.json
+++ b/language/pl.json
@@ -23,10 +23,6 @@
             "description": "Click on the thumbnail image to place the hotspot"
           },
           {
-            "label": "Cover entire background image",
-            "description": "When the user clicks the hotspot the popup will cover the entire background image"
-          },
-          {
             "label": "Header",
             "description": "Optional header for the popup"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Content Item"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Cover entire background image"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/pt-br.json
+++ b/language/pt-br.json
@@ -23,10 +23,6 @@
             "description": "Clique na miniatura da imagem para posicionar o ponto de acesso"
           },
           {
-            "label": "Cobrir a imagem de fundo inteira",
-            "description": "Quando o usuário clicar no ponto de acesso, o popup cobrirá toda a imagem de fundo"
-          },
-          {
             "label": "Cabeçalho",
             "description": "Cabeçalho opcional para o popup"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Item do conteúdo"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Cobrir a imagem de fundo inteira"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/pt.json
+++ b/language/pt.json
@@ -23,10 +23,6 @@
             "description": "Clique na miniatura da imagem para definir o hotspot"
           },
           {
-            "label": "Cobrir a imagem de fundo",
-            "description": "Quando o utilizador clicar no hotspot a janela popup vai cobrir toda a imagem de fundo"
-          },
-          {
             "label": "Cabeçalho",
             "description": "Cabeçalho opcional para a janela popup"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Item de Conteúdo"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Cobrir a imagem de fundo"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/ro.json
+++ b/language/ro.json
@@ -23,10 +23,6 @@
             "description": "Click on the thumbnail image to place the hotspot"
           },
           {
-            "label": "Cover entire background image",
-            "description": "When the user clicks the hotspot the popup will cover the entire background image"
-          },
-          {
             "label": "Header",
             "description": "Optional header for the popup"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Content Item"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Cover entire background image"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/ru.json
+++ b/language/ru.json
@@ -23,10 +23,6 @@
             "description": "Нажмите на уменьшенное изображение для размещения метки"
           },
           {
-            "label": "Обложка всего фонового изображения",
-            "description": "Когда пользователь нажимает на метку, всплывающее окно будет охватывать все фоновое изображение"
-          },
-          {
             "label": "Заголовок",
             "description": "Необязательный заголовок для всплывающего окна"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Элемент содержимого"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Обложка всего фонового изображения"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/sr.json
+++ b/language/sr.json
@@ -23,10 +23,6 @@
             "description": "Click on the thumbnail image to place the hotspot"
           },
           {
-            "label": "Cover entire background image",
-            "description": "When the user clicks the hotspot the popup will cover the entire background image"
-          },
-          {
             "label": "Header",
             "description": "Optional header for the popup"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Content Item"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Cover entire background image"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/sv.json
+++ b/language/sv.json
@@ -23,10 +23,6 @@
             "description": "Click on the thumbnail image to place the hotspot"
           },
           {
-            "label": "Cover entire background image",
-            "description": "When the user clicks the hotspot the popup will cover the entire background image"
-          },
-          {
             "label": "Header",
             "description": "Optional header for the popup"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Content Item"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Cover entire background image"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/tr.json
+++ b/language/tr.json
@@ -23,10 +23,6 @@
             "description": "Click on the thumbnail image to place the hotspot"
           },
           {
-            "label": "Cover entire background image",
-            "description": "When the user clicks the hotspot the popup will cover the entire background image"
-          },
-          {
             "label": "Header",
             "description": "Optional header for the popup"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Content Item"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Cover entire background image"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/uk.json
+++ b/language/uk.json
@@ -23,10 +23,6 @@
             "description": "Натисніть зменшене зображення для розміщення мітки"
           },
           {
-            "label": "Обкладинка всього малюнка тла",
-            "description": "Коли користувач натискає на мітку, випливаюче вікно буде захоплювати весь малюнок тла"
-          },
-          {
             "label": "Заголовок",
             "description": "Необов'язковий заголовок для випливаючого вікна"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Елемент вмісту"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Обкладинка всього малюнка тла"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/vi.json
+++ b/language/vi.json
@@ -23,10 +23,6 @@
             "description": "Click on the thumbnail image to place the hotspot"
           },
           {
-            "label": "Cover entire background image",
-            "description": "When the user clicks the hotspot the popup will cover the entire background image"
-          },
-          {
             "label": "Header",
             "description": "Optional header for the popup"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Content Item"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Cover entire background image"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/zh-hans.json
+++ b/language/zh-hans.json
@@ -23,10 +23,6 @@
             "description": "在缩图上点击以放置热贴。"
           },
           {
-            "label": "弹出视窗布满整个背景图片",
-            "description": "当用户点击热点时，弹出的视窗会与背景图片的尺寸一致。"
-          },
-          {
             "label": "弹出视窗标题文字",
             "description": "弹出视窗上显示的标题。"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "项目"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "弹出视窗布满整个背景图片"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/zh-hant.json
+++ b/language/zh-hant.json
@@ -23,10 +23,6 @@
             "description": "在縮圖上點擊以放置熱點。"
           },
           {
-            "label": "彈出視窗佈滿整個背景圖片",
-            "description": "當用戶點擊熱點時，彈出的視窗會與背景圖片的尺寸一致。"
-          },
-          {
             "label": "彈出視窗標題文字",
             "description": "彈出視窗上顯示的標題。"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "項目"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "彈出視窗佈滿整個背景圖片"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/language/zh-tw.json
+++ b/language/zh-tw.json
@@ -23,10 +23,6 @@
             "description": "Click on the thumbnail image to place the hotspot"
           },
           {
-            "label": "Cover entire background image",
-            "description": "When the user clicks the hotspot the popup will cover the entire background image"
-          },
-          {
             "label": "Header",
             "description": "Optional header for the popup"
           },
@@ -35,6 +31,45 @@
             "field": {
               "label": "Content Item"
             }
+          },
+          {
+            "label": "Popup settings",
+            "fields": [
+              {
+                "label": "Size and position",
+                "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+                "options": [
+                  {
+                    "label": "Cover free space next to hotspot"
+                  },
+                  {
+                    "label": "Cover entire background image"
+                  },
+                  {
+                    "label": "Custom"
+                  }
+                ]
+              },
+              {
+                "label": "Maximum width (in percent)",
+                "description": "The width of the popup will be limited to the percentage relative to the background image's width"
+              },
+              {
+                "label": "Position",
+                "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+                "options": [
+                  {
+                    "label": "Auto"
+                  },
+                  {
+                    "label": "Left of hotspot"
+                  },
+                  {
+                    "label": "Right of hotspot"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/library.json
+++ b/library.json
@@ -54,6 +54,11 @@
       "machineName": "H5PEditor.ColorSelector",
       "majorVersion": 1,
       "minorVersion": 2
+    },
+    {
+      "machineName": "H5PEditor.ShowWhen",
+      "majorVersion": 1,
+      "minorVersion": 0
     }
   ]
 }

--- a/scripts/hotspot.js
+++ b/scripts/hotspot.js
@@ -158,8 +158,9 @@
       self.$element.outerWidth(),
       self.config.header,
       popupClass,
-      self.config.alwaysFullscreen || self.isSmallDeviceCB(),
-      self.options
+      self.config.popupSettings.sizePosition === 'fullscreen' || self.isSmallDeviceCB(),
+      self.options,
+      self.config.popupSettings
     );
 
     // Release

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -17,12 +17,20 @@
    * @param {string} className
    * @param {boolean} fullscreen
    * @param {Object} options
-   *
+   * @param {object} [customSettings] Custom settings.
+   * @param {number} [customSettings.maxWidth=100] Maximum width for popup (percentage).
+   * @param {number} [customSettings.position=0] Force popup left (=1) or right (=2).
    */
-  ImageHotspots.Popup = function ($container, $content, x, y, hotspotWidth, header, className, fullscreen, options) {
+  ImageHotspots.Popup = function ($container, $content, x, y, hotspotWidth, header, className, fullscreen, options, customSettings) {
     EventDispatcher.call(this);
 
     var self = this;
+
+    // Sanitize custom settings
+    customSettings = customSettings || {};
+    const maxWidth = Math.min(100, Math.max(0, customSettings.maxWidth || 100));
+    const forcePos = parseInt(customSettings.position) || ImageHotspots.Popup.FORCE_AUTO;
+
     this.$container = $container;
     var width = this.$container.width();
 
@@ -38,9 +46,17 @@
       className += ' fullscreen-popup';
     }
     else {
-      toTheLeft = (x > 45);
-      popupLeft = (toTheLeft ? 0 : (x + hotspotWidth + pointerWidthInPercent));
-      popupWidth = (toTheLeft ?  x - pointerWidthInPercent : 100 - popupLeft);
+      // Determine position of popup in relation to the hotspot
+      toTheLeft = ((x > 45) || forcePos === ImageHotspots.Popup.FORCE_LEFT) && (forcePos !== ImageHotspots.Popup.FORCE_RIGHT);
+
+      if (toTheLeft) {
+        popupWidth = Math.min(x - pointerWidthInPercent, maxWidth);
+        popupLeft = x - pointerWidthInPercent - popupWidth;
+      }
+      else {
+        popupWidth = Math.min(100 - (x + hotspotWidth + pointerWidthInPercent), maxWidth);
+        popupLeft = x + hotspotWidth + pointerWidthInPercent;
+      }
     }
 
     this.$popupBackground = $('<div/>', {'class': 'h5p-image-hotspots-overlay'});
@@ -187,5 +203,12 @@
   // Extends the event dispatcher
   ImageHotspots.Popup.prototype = Object.create(EventDispatcher.prototype);
   ImageHotspots.Popup.prototype.constructor = ImageHotspots.Popup;
+
+  /** @constant {number} */
+  ImageHotspots.Popup.FORCE_AUTO = 0;
+  /** @constant {number} */
+  ImageHotspots.Popup.FORCE_LEFT = 1;
+  /** @constant {number} */
+  ImageHotspots.Popup.FORCE_RIGHT = 2;
 
 })(H5P.jQuery, H5P.ImageHotspots, H5P.EventDispatcher);

--- a/semantics.json
+++ b/semantics.json
@@ -64,13 +64,6 @@
           ]
         },
         {
-          "name": "alwaysFullscreen",
-          "type": "boolean",
-          "label": "Cover entire background image",
-          "importance": "low",
-          "description": "When the user clicks the hotspot the popup will cover the entire background image"
-        },
-        {
           "name": "header",
           "type": "text",
           "label": "Header",
@@ -93,6 +86,87 @@
               "H5P.Image 1.1"
             ]
           }
+        },
+        {
+          "name": "popupSettings",
+          "type": "group",
+          "label": "Popup settings",
+          "importance": "medium",
+          "fields": [
+            {
+              "name": "sizePosition",
+              "type": "select",
+              "label": "Size and position",
+              "importance": "low",
+              "description": "Decide how much space the popup will take when the user clicks on a hotspot",
+              "options": [
+                {
+                  "value": "free",
+                  "label": "Cover free space next to hotspot"
+                },
+                {
+                  "value": "fullscreen",
+                  "label": "Cover entire background image"
+                },
+                {
+                  "value": "custom",
+                  "label": "Custom"
+                }
+              ],
+              "default": "free"
+            },
+            {
+              "name": "maxWidth",
+              "type": "number",
+              "label": "Maximum width (in percent)",
+              "description": "The width of the popup will be limited to the percentage relative to the background image's width",
+              "importance": "low",
+              "default": 100,
+              "min": 10,
+              "max": 100,
+              "optional": true,
+              "widget": "showWhen",
+              "showWhen": {
+                "rules": [
+                  {
+                    "field": "sizePosition",
+                    "equals": "custom"
+                  }
+                ]
+              }
+            },
+            {
+              "name": "position",
+              "type": "select",
+              "label": "Position",
+              "description": "By default, the popup will be placed left or right of the corresponding hotspot depending on where there's more space",
+              "importance": "low",
+              "options": [
+                {
+                  "value": "0",
+                  "label": "Auto"
+                },
+                {
+                  "value": "1",
+                  "label": "Left of hotspot"
+                },
+                {
+                  "value": "2",
+                  "label": "Right of hotspot"
+                }
+              ],
+              "default": "0",
+              "widget": "showWhen",
+              "showWhen": {
+                "rules": [
+                  {
+                    "field": "sizePosition",
+                    "equals": "custom"
+                  }
+                ]
+              }
+            }
+          ]
         }
       ]
     }

--- a/upgrades.js
+++ b/upgrades.js
@@ -81,6 +81,11 @@ H5PUpgrades['H5P.ImageHotspots'] = (function () {
             if (hotspot.position) {
               hotspot.position.legacyPositioning = true;
             }
+
+            // Move "always fullscreen" option to popup settings group
+            hotspot.popupSettings = {};
+            hotspot.popupSettings.sizePosition = (hotspot.alwaysFullscreen === true) ? 'fullscreen' : 'free';
+            delete hotspot.alwaysFullscreen;
           });
         }
         finished(null, parameters);


### PR DESCRIPTION
- Add editor option group for popup size/position to select from
  - Cover free space next to hotspot (currently default)
  - Cover entire background image (currently extra setting)
  - Custom

The latter will allow to set
  - a maximum width for the hotspot (as requested multiple times,
    e.g. in https://h5p.org/node/224462)
  - an override to explicitöy put the popup left or right of the hotspot