### PR TITLE
Fix HTML encoding of hotspot headers

### DIFF
--- a/scripts/image-hotspots.js
+++ b/scripts/image-hotspots.js
@@ -22,6 +22,8 @@ H5P.ImageHotspots = (function ($, EventDispatcher) {
    * @param {number} id
    */
   function ImageHotspots(options, id) {
+    const self = this;
+
     EventDispatcher.call(this);
 
     // Extend defaults with provided options
@@ -33,6 +35,13 @@ H5P.ImageHotspots = (function ($, EventDispatcher) {
       iconType: 'icon',
       icon: 'plus'
     }, options);
+
+    // Sanitize hotspot headers
+    this.options.hotspots.map(function (hotspot) {
+      hotspot.header = self.stripHTML(self.htmlDecode(hotspot.header));
+      return hotspot;
+    });
+
     // Keep provided id.
     this.id = id;
     this.isSmallDevice = false;
@@ -258,6 +267,31 @@ H5P.ImageHotspots = (function ($, EventDispatcher) {
     });
 
     self.isSmallDevice = (containerWidth / parseFloat($("body").css("font-size")) < 40);
+  };
+
+  /**
+   * Retrieve true string from HTML encoded string.
+   *
+   * @public
+   * @param {string} input Input string.
+   * @return {string} Output string.
+   */
+  ImageHotspots.prototype.htmlDecode = function (input) {
+    const dparser = new DOMParser().parseFromString(input, 'text/html');
+    return dparser.documentElement.textContent;
+  };
+
+  /**
+   * Retrieve string without HTML tags.
+   *
+   * @public
+   * @param {string} input Input string.
+   * @return {string} Output string.
+   */
+  ImageHotspots.prototype.stripHTML = function (html) {
+    const div = document.createElement('div');
+    div.innerHTML = html;
+    return div.textContent || div.innerText || '';
   };
 
   return ImageHotspots;


### PR DESCRIPTION
When merged in, will fix the hotspot headers being displayed HTML encoded in the tooltip.
Reported in https://github.com/h5p/h5p-image-hotspots/issues/78.