### PR TITLE
VA-890 Use themed core fullscreen button

### DIFF
--- a/scripts/image-hotspots.js
+++ b/scripts/image-hotspots.js
@@ -175,6 +175,13 @@ H5P.ImageHotspots = (function ($, EventDispatcher) {
     const observer = new IntersectionObserver((entries, observer) => {
       for (let entry of entries) {
         if (entry.intersectionRatio > 0) {
+
+          // Signal to use themed content controls
+          const contentControls = this.$container[0].querySelector('.h5p-content-controls');
+          if (contentControls) {
+            contentControls.classList.add('themed');
+          }
+
           this.trigger('resize');
           return;
         }


### PR DESCRIPTION
When merged in, will use the h5p-theme fullscreen button instead of the legacy fullscreen button.

Requires https://github.com/h5p/h5p-php-library/pull/232