### PR TITLE
HFP-4256 make icon and img size consistent

### DIFF
--- a/styles/image-hotspots.css
+++ b/styles/image-hotspots.css
@@ -42,16 +42,10 @@
   border-radius: 3em;
   transition: all .2s ease-in-out;
   background: var(--h5p-theme-ui-base);
-  padding: var(--h5p-theme-spacing-xxs);
   border: 1px solid transparent;
   margin: 0;
   cursor: pointer;
   box-shadow: 5px 4px 8px 0px rgb(0 0 0 / 36%);
-}
-
-.h5p-image-hotspot img {
-  width: 100%;
-  height: 100%;
 }
 
 .h5p-image-hotspot.disabled {
@@ -82,29 +76,29 @@
   transform: scale(1.5);
 }
 
-.h5p-image-hotspot:before {
+.h5p-image-hotspot::before {
   font-family: h5p-theme;
 }
-.h5p-image-hotspot-plus:before {
+.h5p-image-hotspot-plus::before {
   content: '\e920';
 }
-.h5p-image-hotspot-minus:before {
+.h5p-image-hotspot-minus::before {
   content: '\e923';
 }
-.h5p-image-hotspot-times:before {
+.h5p-image-hotspot-times::before {
   content: '\e921';
 }
-.h5p-image-hotspot-check:before {
+.h5p-image-hotspot-check::before {
   content: '\e926';
 }
 /* Avoid collision with main class name of H5P.ImageHotspotQuestion */
-.h5p-image-hotspots .h5p-image-hotspot-question:before {
+.h5p-image-hotspots .h5p-image-hotspot-question::before {
   content: '\e924';
 }
-.h5p-image-hotspot-info:before {
+.h5p-image-hotspot-info::before {
   content: '\e922';
 }
-.h5p-image-hotspot-exclamation:before {
+.h5p-image-hotspot-exclamation::before {
   content: '\e925';
 }
 .h5p-image-hotspot-popup {
@@ -203,7 +197,7 @@
   overflow: auto;
 }
 /* Make the content fade out a bit if there's a scrollbar */
-.h5p-image-hotspot-popup-content.overflowing:after {
+.h5p-image-hotspot-popup-content.overflowing::after {
   content: '';
   width: calc(100% - 1em);
   height: 10em;
@@ -216,7 +210,7 @@
   pointer-events: none; /* Make things behind it clickable */
 }
 /* When scroll has been detected, remove the content fade-out */
-.h5p-image-hotspot-popup-content.overflowing.has-scrolled:after {
+.h5p-image-hotspot-popup-content.overflowing.has-scrolled::after {
   opacity: 0;
 }
 
@@ -257,7 +251,7 @@
   background-color: var(--h5p-theme-ui-base);
   transition: box-shadow 0.3s, border-color 0.3s;
 }
-.h5p-image-hotspot-close-popup-button:before {
+.h5p-image-hotspot-close-popup-button::before {
   color: var(--h5p-theme-text-primary);
   font-family: 'h5p-theme';
   content: '\e910';


### PR DESCRIPTION
This PR is linked with https://github.com/h5p/h5p-image-hotspots/pull/143 and https://github.com/h5p/h5p-image-hotspots/pull/126 
The size of the hotspot icon and hotspot image is same now. 
<img width="2013" height="1199" alt="image" src="https://github.com/user-attachments/assets/f816779b-bfff-48ae-abc5-56ac01a5db78" />
